### PR TITLE
[15.0][FIX]web_editor: fix LinkPopover in iframe on Firefox

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -23,6 +23,7 @@ const LinkPopoverWidget = Widget.extend({
         this.options = options;
         this.target = target;
         this.$target = $(target);
+        this.container = this.options.container || this.target.ownerDocument.body;
         this.href = this.$target.attr('href'); // for template
         this._dp = new DropPrevious();
     },
@@ -38,7 +39,15 @@ const LinkPopoverWidget = Widget.extend({
         this.$fullUrl = this.$('.o_we_full_url');
 
         // Copy onclick handler
-        const clipboard = new ClipboardJS(
+        // ClipboardJS uses "instanceof" to verify the elements passed to its
+        // constructor. Unfortunately, when the element is within an iframe,
+        // instanceof is not behaving the same across all browsers.
+        const containerWindow = this.container.ownerDocument.defaultView;
+        let _ClipboardJS = ClipboardJS;
+        if (this.$copyLink[0] instanceof containerWindow.HTMLElement) {
+            _ClipboardJS = containerWindow.ClipboardJS;
+        }
+        const clipboard = new _ClipboardJS(
             this.$copyLink[0],
             {text: () => this.target.href} // Absolute href
         );


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In Firefox there is an error by updating links or buttons in the web_editor. For example in the marketing mailing app.

Current behavior before PR:
If I click on a link/button in the marketing mail app to update it, theres following error:
![image](https://user-images.githubusercontent.com/44615873/228449886-6eb010ea-b4d8-4b07-af8c-bd2898ad768c.png)


Desired behavior after PR is merged:
There is no more error by updating links/buttons in the web_editor in Firefox.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
