### PR TITLE
[15.0][FIX] font-family in style attribute in web editor

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -363,10 +363,6 @@ function classToStyle($editable, cssRules) {
                 writes.push(() => { node.style[styleName] = ''; });
             }
         }
-        // Ignore font-family (mail-safe font declared in <head>)
-        if ('font-family' in css) {
-            delete css['font-family'];
-        }
 
         // Do not apply css that would override inline styles (which are prioritary).
         let style = node.getAttribute('style') || '';


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
for example if we send emails from mail compose wizard, the mail is not sent with font-family Arial, but it should be Arial because it's written in css.

Current behavior before PR:
![image](https://user-images.githubusercontent.com/44615873/228477458-95a8ea86-cec0-440f-820c-4312542cb8a4.png)


Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/44615873/228477637-67925b0a-066a-4717-b6ad-1d608fe68d8a.png)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
