### PR TITLE
[17.0][UPD] Werkzeug library fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,8 +75,7 @@ rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Nee
 urllib3==1.26.5 ; python_version < '3.12' # indirect / min version = 1.25.8 (Focal with security backports)
 urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
 vobject==0.9.6.1
-Werkzeug==2.0.2 ; python_version <= '3.10' 
-Werkzeug==2.2.2 ; python_version > '3.10' and python_version < '3.12'
+Werkzeug==2.0.2 ; python_version < '3.12'
 Werkzeug==3.0.1 ; python_version >= '3.12'  # (Noble) Avoid deprecation warnings
 xlrd==1.2.0 ; python_version < '3.12'  # (jammy)
 xlrd==2.0.1 ; python_version >= '3.12'


### PR DESCRIPTION
`Werkzeug==2.2.2` library with Python 3.11 brings a problem with file download when the filename has utf-8 characters, for example: `Diplômes UniDistance (compressé).pdf`

Manual update on the server can be done with these commands (execute with Odoo user):
```
/opt/odoo/venv/bin/pip uninstall Werkzeug -y

/opt/odoo/venv/bin/pip install Werkzeug==2.0.2
```